### PR TITLE
curl version of imagemagick

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,7 @@ ARG BUILD_DATE
 ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 
-# package versions
-ARG IMAGEMAGICK_VER="6.9.9-0"
-
-# install build packages
+# install build packages
 RUN \
  apk add --no-cache --virtual=build-dependencies \
 	file \
@@ -45,12 +42,15 @@ RUN \
 	tiff \
 	zlib && \
 
-# compile imagemagic
+# compile imagemagic
+ IMAGEMAGICK_VER=$(curl --silent http://www.imagemagick.org/download/digest.rdf \
+	| grep ImageMagick-6.*tar.xz | sed 's/\(.*\).tar.*/\1/' \
+	| sed 's/^.*ImageMagick-/ImageMagick-/') && \
  mkdir -p \
 	/tmp/imagemagick && \
  curl -o \
  /tmp/imagemagick-src.tar.xz -L \
-	"http://www.imagemagick.org/download/releases/ImageMagick-${IMAGEMAGICK_VER}.tar.xz" && \
+	"http://www.imagemagick.org/download/${IMAGEMAGICK_VER}.tar.xz" && \
  tar xf \
  /tmp/imagemagick-src.tar.xz -C \
 	/tmp/imagemagick --strip-components=1 && \
@@ -76,7 +76,7 @@ RUN \
  find / -name '.packlist' -o -name 'perllocal.pod' \
 	-o -name '*.bs' -delete && \
 
-# install calibre-web
+# install calibre-web
  mkdir -p \
 	/app/calibre-web && \
  curl -o \
@@ -91,15 +91,15 @@ RUN \
  pip install --no-cache-dir -U -r \
 	optional-requirements.txt && \
 
-# cleanup
+# cleanup
  apk del --purge \
 	build-dependencies && \
  rm -rf \
 	/tmp/*
 
-# add local files
+# add local files
 COPY root/ /
 
-# ports and volumes
+# ports and volumes
 EXPOSE 8083
 VOLUME /books /config

--- a/README.md
+++ b/README.md
@@ -99,4 +99,5 @@ To reverse proxy with our Letsencrypt docker container use the following locatio
 
 ## Versions
 
++ **24.07.17:** Curl version for imagemagick.
 + **17.07.17:** Initial release


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ curl latest version of imagemagick 6 from digest
+ should prevent the curl of source files failing caused by deletion of previous versions from download site